### PR TITLE
fix UNK bug

### DIFF
--- a/srl/utils/io_utils.py
+++ b/srl/utils/io_utils.py
@@ -162,6 +162,7 @@ def load_init_emb(init_emb):
     if vec.get(UNK) is None:
         """ averaging """
         avg = np.zeros(dim, dtype=theano.config.floatX)
+        emb[vocab.get_id(UNK)] = avg
         for i in xrange(len(emb)):
             avg += emb[i]
         avg_vec = avg / len(emb)


### PR DESCRIPTION
The execution of the if-statement (l. 162) gives 

`ValueError: operands could not be broadcast together with shapes (32,) (0,) (32,)`, which is because `emb` is an empty list at UNK's position. In the fix, I replace the empty list with a 0-vector.
